### PR TITLE
domain validation options bug

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,8 +59,8 @@ resource "aws_acm_certificate_validation" "us_west_2" {
 ##################################
 resource "cloudflare_record" "validation" {
   zone_id = var.root_zone_id
-  name    = trim(aws_acm_certificate.us_east_1.domain_validation_options.0.resource_record_name, ".")
-  value   = trim(aws_acm_certificate.us_east_1.domain_validation_options.0.resource_record_value, ".")
+  name    = trim(tolist(aws_acm_certificate.us_east_1.domain_validation_options).0.resource_record_name, ".")
+  value   = trim(tolist(aws_acm_certificate.us_east_1.domain_validation_options).0.resource_record_value, ".")
   type    = "CNAME"
   ttl     = 120
 }


### PR DESCRIPTION
This module has a bug as a result of its last update. The data type of the domain_validation_options value changed from a list to a set, so it can't be accessed using normal array indices anymore. To fix it I followed the advice from this gh issue comment: https://github.com/hashicorp/terraform/issues/26043#issuecomment-683119243
